### PR TITLE
Update API Version in Manifest

### DIFF
--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -628,5 +628,5 @@
     <members>*</members>
     <name>Workflow</name>
   </types>
-  <version>52.0</version>
+  <version>53.0</version>
 </Package>


### PR DESCRIPTION
Tries to fix a bug with deploying FlexiPage records by updating to the Spring 22 API version.